### PR TITLE
✨ feat: Navigation fonctionnelle depuis le Hero Banner vers la page détail produit

### DIFF
--- a/src/app/features/home/components/hero/hero.component.ts
+++ b/src/app/features/home/components/hero/hero.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-hero',
@@ -10,9 +11,11 @@ export class HeroComponent {
   productTitle = 'XX99 MARK II HEADPHONES';
   productDescription =
     'Experience natural, lifelike audio and exceptional build quality made for the passionate music enthusiast.';
+  productSlug = 'xx99-mark-two-headphones';
+
+  constructor(private _router: Router) {}
 
   onSeeProduct() {
-    // Navigation vers la page de détail du produit
-    console.log('Navigate to product details');
+    this._router.navigate(['/products', this.productSlug]);
   }
 }


### PR DESCRIPTION
## Description

Cette PR implémente la navigation depuis le composant Hero de la page d'accueil vers la page détail du produit mis en avant (XX99 Mark II Headphones).

## Modifications

- Ajout de la propriété productSlug au HeroComponent pour stocker l'identifiant du produit
- Injection du Router dans le composant
- Modification de la méthode onSeeProduct() pour naviguer vers la page détail produit correspondante

## Tests effectués

✅ Clic sur le bouton "SEE PRODUCT" du Hero
✅ Navigation vers la page détail du XX99 Mark II Headphones
✅ Vérification du fonctionnement sur mobile et desktop

## Captures d'écran
N/A - Modification fonctionnelle sans impact visuel